### PR TITLE
Extend naming convention rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@rushstack/eslint-patch": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",

--- a/profile/_common.js
+++ b/profile/_common.js
@@ -231,7 +231,7 @@ function buildRules(profile) {
             },
             {
               selector: ["objectLiteralProperty", "objectLiteralMethod"],
-              format: ["camelCase", "PascalCase", "snake_case"],
+              format: ["camelCase", "PascalCase", "snake_case", "UPPER_CASE"],
               leadingUnderscore: "allowDouble",
             },
             {


### PR DESCRIPTION
# What

- Allow UPPER_CASE formatting for object properties

## Compatibility

- [x] Does this change maintain backward compatibility?
