### PR TITLE
extend varsIgnorePattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@rushstack/eslint-patch": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",

--- a/profile/_common.js
+++ b/profile/_common.js
@@ -252,7 +252,7 @@ function buildRules(profile) {
           "@typescript-eslint/consistent-type-definitions": ["error", "type"],
           "@typescript-eslint/no-unused-vars": [
             "error",
-            { varsIgnorePattern: "[iI]gnored", argsIgnorePattern: "^_" },
+            { varsIgnorePattern: "[iI]gnored|_", argsIgnorePattern: "^_" },
           ],
           "@typescript-eslint/no-shadow": "error",
         },

--- a/profile/_common.js
+++ b/profile/_common.js
@@ -252,7 +252,7 @@ function buildRules(profile) {
           "@typescript-eslint/consistent-type-definitions": ["error", "type"],
           "@typescript-eslint/no-unused-vars": [
             "error",
-            { varsIgnorePattern: "[iI]gnored|_", argsIgnorePattern: "^_" },
+            { varsIgnorePattern: "[iI]gnored|^_", argsIgnorePattern: "^_" },
           ],
           "@typescript-eslint/no-shadow": "error",
         },


### PR DESCRIPTION
# What

- Extended `varsIgnorePattern` rule to allow `^_`, which is commonly used in TypeScript utils

## Compatibility

- [x] Does this change maintain backward compatibility?
