### PR TITLE
Minor updates

### DIFF
--- a/mixins/graphql/schema.js
+++ b/mixins/graphql/schema.js
@@ -116,7 +116,19 @@ module.exports = {
          */
         "@graphql-eslint/require-description": [
           "warn",
-          { types: false, DirectiveDefinition: true },
+          {
+            DirectiveDefinition: true,
+            rootField: true,
+            InputValueDefinition: true,
+            types: false,
+            InputObjectTypeDefinition: false,
+            ObjectTypeDefinition: false,
+            InterfaceTypeDefinition: false,
+            EnumTypeDefinition: false,
+            ScalarTypeDefinition: false,
+            UnionTypeDefinition: false,
+            EnumValueDefinition: false,
+          },
         ],
 
         /**

--- a/profile/_common.js
+++ b/profile/_common.js
@@ -514,17 +514,8 @@ function buildRules(profile) {
               leadingUnderscore: "forbid",
             },
             {
-              selector: ["objectLiteralProperty", "objectLiteralMethod"],
-              format: ["camelCase", "PascalCase", "snake_case", "UPPER_CASE"],
-              leadingUnderscore: "allowDouble",
-              filter: {
-                regex: "^(&:)|^[0-9]+$",
-                match: false,
-              },
-            },
-            {
               selector: ["typeProperty"],
-              format: ["camelCase", "snake_case"],
+              format: ["camelCase"],
               leadingUnderscore: "allowDouble",
               filter: {
                 regex: "^(Component)$",


### PR DESCRIPTION
# What

- Updated graphql naming convention for `schema` profile
- Removed restriction for naming object properties

## Compatibility

- [ ] Does this change maintain backward compatibility?
