### PR TITLE
Update no-unused-expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "4.16.0",
+      "version": "4.16.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-eslint/eslint-plugin": "^3.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",

--- a/profile/_common.js
+++ b/profile/_common.js
@@ -797,7 +797,7 @@ function buildRules(profile) {
            */
           "@typescript-eslint/no-unused-expressions": [
             "warn",
-            { allowShortCircuit: true },
+            { allowShortCircuit: true, allowTaggedTemplates: true },
           ],
           "no-unused-expressions": "off",
 


### PR DESCRIPTION
# What

- Allow tagged template literals (useful for `gql`)

## Compatibility

- [ ] Does this change maintain backward compatibility?
