### PR TITLE
Update GraphQL mixin

### DIFF
--- a/mixins/graphql/schema.js
+++ b/mixins/graphql/schema.js
@@ -128,10 +128,11 @@ module.exports = {
         /**
          * Requires output types to have one unique identifier unless they do not have a logical one.
          * Exceptions can be used to ignore output types that do not have unique identifiers.
+         * DISABLED - reports false-positives in modularized schemas
          * @see https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/strict-id-in-types.md
          */
         "@graphql-eslint/strict-id-in-types": [
-          "warn",
+          "off",
           {
             acceptedIdNames: ["id", "nid"],
             acceptedIdTypes: ["ID"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "4.16.1",
+  "version": "4.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "4.16.1",
+      "version": "4.16.2",
       "license": "MIT",
       "dependencies": {
         "@graphql-eslint/eslint-plugin": "^3.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "4.16.1",
+  "version": "4.16.2",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",


### PR DESCRIPTION
# What

- Disabled `@graphql-eslint/strict-id-in-types` rule, which reported false-positives for modular schemas

## Compatibility

- [ ] Does this change maintain backward compatibility?
