### PR TITLE
Fix invalid prettier config value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "4.16.2",
+      "version": "4.16.3",
       "license": "MIT",
       "dependencies": {
         "@graphql-eslint/eslint-plugin": "^3.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -30,7 +30,7 @@ module.exports = {
         singleQuote: false,
         parser: "json5",
         quoteProps: "preserve",
-        trailingComma: false,
+        trailingComma: "none",
       },
     },
   ],


### PR DESCRIPTION
# What

- `trailingComma` value was invalid, causing script formatting `json5` files to fail

## Compatibility

- [x] Does this change maintain backward compatibility?
