### PR TITLE
Replace deprecated eslint-config-node

### DIFF
--- a/mixins/node.js
+++ b/mixins/node.js
@@ -8,7 +8,7 @@ module.exports = {
   overrides: [
     {
       files: ["**/*.js", "**/*.mjs", "**/*.ts"],
-      plugins: ["node"],
+      plugins: ["n"],
       globals: {
         ...globals.node,
         ...globals.commonjs,
@@ -34,81 +34,81 @@ module.exports = {
         "@typescript-eslint/no-var-requires": "off",
 
         // ====================================================================================================
-        // eslint-plugin-node
+        // eslint-plugin-n
         // ====================================================================================================
         /**
          * Prevent assignment to `exports` variable, it would not work as expected.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-exports-assign.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-exports-assign.md
          */
-        "node/no-exports-assign": "error",
+        "n/no-exports-assign": "error",
 
         /**
          * If an import declaration's source is extraneous (it's not written in package.json), the program works in local, but will not work after dependencies are re-installed.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-extraneous-import.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-extraneous-import.md
          */
-        "node/no-extraneous-import": "error",
+        "n/no-extraneous-import": "error",
 
         /**
          * If a require()'s target is extraneous (it's not written in package.json), the program works in local, but will not work after dependencies are re-installed.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-extraneous-require.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-extraneous-require.md
          */
-        "node/no-extraneous-require": "error",
+        "n/no-extraneous-require": "error",
 
         /**
          * Disallow import declarations which import non-existence modules.
          * DISABLED - reports false-positives
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-missing-import.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-missing-import.md
          */
-        "node/no-missing-import": "off",
+        "n/no-missing-import": "off",
 
         /**
          * Disallow require() expressions which import non-existence modules
          * DISABLED - reports false-positives
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-missing-require.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-missing-require.md
          */
-        "node/no-missing-require": "off",
+        "n/no-missing-require": "off",
 
         /**
          * Disallow new operators with calls to require, they might be confusing.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-new-require.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-new-require.md
          */
-        "node/no-new-require": "error",
+        "n/no-new-require": "error",
 
         /**
          * Both path.join() and path.resolve() are suitable replacements for string concatenation wherever file or directory paths are being created.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-path-concat.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-path-concat.md
          */
-        "node/no-path-concat": "error",
+        "n/no-path-concat": "error",
 
         /**
          * Prevents install failure of a published package.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unpublished-bin.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unpublished-bin.md
          */
-        "node/no-unpublished-bin": "error",
+        "n/no-unpublished-bin": "error",
 
         /**
          * Prevents install failure of a published package.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unpublished-import.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unpublished-import.md
          */
-        "node/no-unpublished-import": "error",
+        "n/no-unpublished-import": "off",
 
         /**
          * Prevents install failure of a published package.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unpublished-require.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unpublished-require.md
          */
-        "node/no-unpublished-require": "error",
+        "n/no-unpublished-require": "error",
 
         /**
          * Prevents using unsupported features.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unsupported-features/es-builtins.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unsupported-features/es-builtins.md
          */
-        "node/no-unsupported-features/es-builtins": "error",
+        "n/no-unsupported-features/es-builtins": "error",
 
         /**
          * Prevents using unsupported features.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unsupported-features/es-syntax.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unsupported-features/es-syntax.md
          */
-        "node/no-unsupported-features/es-syntax": [
+        "n/no-unsupported-features/es-syntax": [
           "error",
           {
             ignores: ["modules"],
@@ -117,99 +117,99 @@ module.exports = {
 
         /**
          * Prevents using unsupported features.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unsupported-features/node-builtins.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-unsupported-features/node-builtins.md
          */
-        "node/no-unsupported-features/node-builtins": "error",
+        "n/no-unsupported-features/node-builtins": "error",
 
         /**
          * Make process.exit() expressions the same code path as throw for eslint.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/process-exit-as-throw.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/process-exit-as-throw.md
          */
-        "node/process-exit-as-throw": "error",
+        "n/process-exit-as-throw": "error",
 
         /**
          * When we make a CLI tool with Node.js, we add bin field to package.json, then we add a shebang the entry file. This rule suggests correct usage of shebang.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/shebang.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/shebang.md
          */
-        "node/shebang": "error",
+        "n/shebang": "error",
 
         /**
          * Prevent using deprecated APIs that might get removed in future versions of Node.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-deprecated-api.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-deprecated-api.md
          */
-        "node/no-deprecated-api": "error",
+        "n/no-deprecated-api": "error",
 
         /**
          * To prevent calling the callback multiple times it is important to return anytime the callback is triggered outside of the main function body.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/callback-return.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/callback-return.md
          */
-        "node/callback-return": "error",
+        "n/callback-return": "error",
 
         /**
          * Enforce export style to achieve consistency within codebase.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/exports-style.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/exports-style.md
          */
-        "node/exports-style": ["error", "module.exports"],
+        "n/exports-style": ["error", "module.exports"],
 
         /**
          * While require() may be called anywhere in code, some style guides prescribe that it should be called only in the top level of a module to make it easier to identify dependencies.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/global-require.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/global-require.md
          */
-        "node/global-require": "error",
+        "n/global-require": "error",
 
         /**
          * In the Node.js community it is often customary to separate initializations with calls to require modules from other variable declarations, sometimes also grouping them by the type of module.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-mixed-requires.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/no-mixed-requires.md
          */
-        "node/no-mixed-requires": "error",
+        "n/no-mixed-requires": "error",
 
         /**
          * Force usage of global variable for consistency.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/buffer.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/buffer.md
          */
-        "node/prefer-global/buffer": ["error", "always"],
+        "n/prefer-global/buffer": ["error", "always"],
 
         /**
          * Force usage of global variable for consistency.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/console.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/console.md
          */
-        "node/prefer-global/console": ["error", "always"],
+        "n/prefer-global/console": ["error", "always"],
 
         /**
          * Force usage of global variable for consistency.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/console.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/console.md
          */
-        "node/prefer-global/console": ["error", "always"],
+        "n/prefer-global/console": ["error", "always"],
 
         /**
          * Force usage of global variable for consistency.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/process.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/process.md
          */
-        "node/prefer-global/process": ["error", "always"],
+        "n/prefer-global/process": ["error", "always"],
 
         /**
          * Force usage of global variable for consistency.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/url-search-params.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/url-search-params.md
          */
-        "node/prefer-global/url-search-params": ["error", "always"],
+        "n/prefer-global/url-search-params": ["error", "always"],
 
         /**
          * Force usage of global variable for consistency.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/url.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-global/url.md
          */
-        "node/prefer-global/url": ["error", "always"],
+        "n/prefer-global/url": ["error", "always"],
 
         /**
          * Promise API and async/await syntax will make code more readable than callback API.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-promises/dns.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-promises/dns.md
          */
-        "node/prefer-promises/dns": "error",
+        "n/prefer-promises/dns": "error",
 
         /**
          * Promise API and async/await syntax will make code more readable than callback API.
-         * @see https://github.com/mysticatea/eslint-plugin-node/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-promises/fs.md
+         * @see https://github.com/mysticatea/eslint-plugin-n/blob/f45c6149be7235c0f7422d1179c25726afeecd83/docs/rules/prefer-promises/fs.md
          */
-        "node/prefer-promises/fs": "error",
+        "n/prefer-promises/fs": "error",
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "5.3.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-eslint/eslint-plugin": "^3.14.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/eslint-config-pat",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-eslint/eslint-plugin": "^3.14.3",
@@ -20,7 +20,7 @@
         "eslint-plugin-jest-dom": "^4.0.3",
         "eslint-plugin-jsdoc": "^44.2.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^16.0.2",
         "eslint-plugin-playwright": "^0.12.0",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.31.11",
@@ -390,9 +390,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz",
-      "integrity": "sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -400,7 +400,7 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
@@ -409,6 +409,14 @@
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1702,6 +1710,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -2226,22 +2242,22 @@
         "node": ">=4"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
+      "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
       "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
-        "eslint": ">=4.19.1"
+        "eslint": ">=8"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -2390,31 +2406,28 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.2.tgz",
+      "integrity": "sha512-Y66uDfUNbBzypsr0kELWrIz+5skicECrLUqlWuXawNSLUq3ltGlCwu6phboYYOTSnoTdHgTLrc+5Ydo6KjzZog==",
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.1.0",
+        "ignore": "^5.2.4",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-playwright": {
@@ -2608,28 +2621,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -3337,9 +3328,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -3477,9 +3468,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -4720,11 +4711,11 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -4811,9 +4802,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5826,9 +5817,9 @@
       }
     },
     "@eslint-community/eslint-utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz",
-      "integrity": "sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
       "requires": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -5839,6 +5830,11 @@
           "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
         }
       }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg=="
     },
     "@eslint/eslintrc": {
       "version": "1.4.0",
@@ -6858,6 +6854,14 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="
     },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "requires": {
+        "semver": "^7.0.0"
+      }
+    },
     "busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -7335,13 +7339,13 @@
         }
       }
     },
-    "eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+    "eslint-plugin-es-x": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
+      "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
       "requires": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0"
       }
     },
     "eslint-plugin-import": {
@@ -7447,24 +7451,19 @@
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-n": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.2.tgz",
+      "integrity": "sha512-Y66uDfUNbBzypsr0kELWrIz+5skicECrLUqlWuXawNSLUq3ltGlCwu6phboYYOTSnoTdHgTLrc+5Ydo6KjzZog==",
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.1.0",
+        "ignore": "^5.2.4",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
       }
     },
     "eslint-plugin-playwright": {
@@ -7587,21 +7586,6 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "requires": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
-        }
       }
     },
     "eslint-visitor-keys": {
@@ -8026,9 +8010,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -8124,9 +8108,9 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -8984,11 +8968,11 @@
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -9039,9 +9023,9 @@
       }
     },
     "semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordcloud/eslint-config-pat",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Shareable ESLint config for PAT projects",
   "author": "Nordcloud Engineering",
   "license": "MIT",
@@ -73,7 +73,7 @@
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-jsdoc": "^44.2.4",
     "eslint-plugin-jsx-a11y": "^6.6.1",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^16.0.2",
     "eslint-plugin-playwright": "^0.12.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.31.11",


### PR DESCRIPTION
# What

This is a breaking change, will require additional work for users of the node mixin
- Replaced deprecated `eslint-config-node` with actively maintainer `eslint-config-n`

## Compatibility

- [ ] Does this change maintain backward compatibility?
