### PR TITLE
feat: automate github release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
         run: npm ci
       - name: Release
         uses: JoshuaKGoldberg/release-it-action@v0.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           branch: 'master'
-          github-token: ${{ secrets.GH_TOKEN }}
           npm-token: ${{ secrets.NPM_KEY }}


### PR DESCRIPTION
# What

- Pass github token to env so the release-it action can perform a github release automatically

## Compatibility

- [x] Does this change maintain backward compatibility?
