### PR TITLE
fix: [AP-6368] update lodash & npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2386,9 +2386,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7171,9 +7172,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -12582,9 +12584,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -13172,7 +13174,7 @@
       "requires": {
         "is-text-path": "^1.0.1",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.0",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -14244,7 +14246,7 @@
       "requires": {
         "debug": "^4.3.2",
         "eslint-compat-utils": "^0.6.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "natural-compare": "^1.4.0",
         "yaml-eslint-parser": "^1.2.1"
       },
@@ -15098,7 +15100,7 @@
         "cli-width": "^4.1.0",
         "external-editor": "^3.1.0",
         "figures": "^5.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "mute-stream": "1.0.0",
         "ora": "^5.4.1",
         "run-async": "^3.0.0",
@@ -15798,9 +15800,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -16950,7 +16952,7 @@
         "inquirer": "9.2.11",
         "is-ci": "3.0.1",
         "issue-parser": "6.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.18.0",
         "mime-types": "2.1.35",
         "new-github-release-url": "2.0.0",
         "node-fetch": "3.3.2",
@@ -18391,7 +18393,7 @@
       "integrity": "sha512-pEwzfsKbTrB8G3xc/sN7aw1v6A6c/pKxLAkjclnAyo5g5qOh6eL9WGu0o3cSDQZKrTNk4KL4lQSwZW+nBkANEg==",
       "requires": {
         "eslint-visitor-keys": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "yaml": "^2.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@babel/traverse": "~7.23.2",
     "pac-resolver": "~7.0.1",
     "socks": "~2.8.3",
-    "@graphql-tools/url-loader": "~8.0.0"
+    "@graphql-tools/url-loader": "~8.0.0",
+    "lodash": "^4.18.0"
   }
 }


### PR DESCRIPTION
# What

require minimum lodash 4.18 

## Compatibility

- [x] Does this change maintain backward compatibility?
